### PR TITLE
Display PR link at end

### DIFF
--- a/gh-git-open-pull
+++ b/gh-git-open-pull
@@ -65,14 +65,16 @@ git push $remote $branchName
 
 # create pull request
 head=$(printf "%s:%s" $userName $branchName)
-gh api -XPOST /repos/{owner}/{repo}/pulls \
+prLink=$(gh api -XPOST /repos/{owner}/{repo}/pulls \
   -F base=$baseBranch \
   -F head=$head \
-  -F issue=$issueNumber > /tmp/gh-git-open-pull.log
+  -F issue=$issueNumber > /tmp/gh-git-open-pull.log)
 
 status=$?
 if [[ $status != 0 ]]; then
   printf "There was an error creating your PR. See log: %s\n" $logfile
   exit 1
 fi
+
+printf "\nPR created: %s\n" $prLink
 


### PR DESCRIPTION

Get the link to the PR from the `gh api` call.
Display the link on successful creation.
